### PR TITLE
Typo in repo name

### DIFF
--- a/library.json
+++ b/library.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/kanewallmann/eeprom-24XX512-arduino.git"
+    "url": "https://github.com/kanewallmann/eeprom-24XX512-ardiuno.git"
   },
   "version": "1.0.1",
   "licence": "MIT",


### PR DESCRIPTION
Please fix typo in a repo name (rename repo) and close this PR.